### PR TITLE
fix: cache file names longer than 260

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -181,7 +181,19 @@ function versiondir($app, $version, $global) { "$(appdir $app $global)\$version"
 function persistdir($app, $global) { "$(basedir $global)\persist\$app" }
 function usermanifestsdir { "$(basedir)\workspace" }
 function usermanifest($app) { "$(usermanifestsdir)\$app.json" }
-function cache_path($app, $version, $url) { "$cachedir\$app#$version#$($url -replace '[^\w\.\-]+', '_')" }
+function cache_path($app, $version, $url) {
+    $filename = "$app#$version#$url"
+    if ($filename.Length -ge 260) {
+        $url = $url -replace '\?.*', ''
+        $filename = "$app#$version#$url"
+        if ($filename.Length -ge 260) {
+            $filename = "$app#$version#$(Split-Path $url -leaf)"
+        }
+    }
+    $filename = $filename -replace '[^\w\.\-\#]+', '_'
+    $path = Join-Path $SCOOP_CACHE_DIRECTORY $filename
+    return $path
+}
 
 # apps
 function sanitary_path($path) { return [regex]::replace($path, "[/\\?:*<>|]", "") }


### PR DESCRIPTION
Fix: #4327
Normally, this function behaves as before when the cache filename is less than 260 characters long.
The modified program is designed to shorten cached filenames while retaining as much complete URL information as possible.
If the filename is greater than or equal to 260 characters in length, it will first attempt to remove everything after the question mark from the URL, and if it is still greater than 260 in length, only the filename in the URL will be retained.
Tested locally and passed.